### PR TITLE
Issue #2: add custom USER_AGENT

### DIFF
--- a/fadecut
+++ b/fadecut
@@ -62,6 +62,7 @@ VERBOSE=0					# verbosity level
 LOOP_INTERVAL=10				# loop interval in seconds
 RESTART_STREAMRIPPER_INTERVAL=900		# restart interval streamripper
 STREAMRIPPER_START=0 				# start streamripper [0/1]
+USER_AGENT="Streamripper/1.x"		# streamripper useragent
 STREAMRIPPER_OPTS="-o always -T"		# streamripper options
 
 E_NOARGS=65					# standard errorlevel definition
@@ -206,6 +207,7 @@ then
   $BIN_STREAMRIPPER $STREAM_URL -d . \
                       --codeset-filesys=utf8 \
                       --codeset-id3=ISO-8859-1 \
+					  -u $USER_AGENT \
                       -s $STREAMRIPPER_OPTS \
                       > $LOGDIR/fadecutstream-$PID.log 2>&1 & 
   PidStreamripper=$!

--- a/fadecut.1
+++ b/fadecut.1
@@ -132,6 +132,11 @@ FADE_OUT=4
 .RS
 Fade out for <n> seconds.
 .RE
+.PP
+USER_AGENT="Streamripper/1.x"
+.RS
+Set the user-agent used by streamripper
+.RE
 .SH EXAMPLES
 Create a new ripping profile
 .RS


### PR DESCRIPTION
(redo from clean state)

By default: use streamripper's default user-agent (Streamripper/1.x)

Adding USER_AGENT="(something)" to profile makes streamripper use a custom user-agent (for example: "VLC/2.0.5" ).

Changing the user-agent is up to the user, who should take Streamripper's rejection into account (serveradmin may not wish to see his stream ripped).

added code considered public domain - no attribution needed :wink:
