### PR TITLE
Add debian branch name in Vcs-Git control field, since the default branch on github is 'master'.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fadecut (0.2.1-2) UNRELEASED; urgency=medium
+
+  * Add debian branch in Vcs-Git field/
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 01:07:50 +0100
+
 fadecut (0.2.1-1) unstable; urgency=low
 
   * New 0.2.1 upstream release

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends: debhelper (>= 10),
                mediainfo (>= 0.7.80)
 Standards-Version: 4.1.1
 Vcs-Browser: https://github.com/fadecut/fadecut/tree/debian
-Vcs-Git: https://github.com/fadecut/fadecut.git
+Vcs-Git: https://github.com/fadecut/fadecut.git -b debian
 Homepage: http://github.com/fadecut/fadecut
 
 Package: fadecut


### PR DESCRIPTION
Add debian branch name in Vcs-Git control field, since the default branch on github is 'master'.
